### PR TITLE
DSND: 2999: Retry more error types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>uk.gov.companieshouse</groupId>
     <artifactId>companies-house-parent</artifactId>
-    <version>2.1.5</version>
+    <version>2.1.6</version>
   </parent>
 
   <artifactId>registers-delta-consumer</artifactId>
@@ -121,6 +121,10 @@
         <exclusion>
           <groupId>io.grpc</groupId>
           <artifactId>grpc-context</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.nimbusds</groupId>
+          <artifactId>nimbus-jose-jwt</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
* All API client errors, apart from 400 and 409, are now retryable
* Updated the POM to bring in the latest parent version and to exclude dependencies with known CVEs

[DSND-2999](https://companieshouse.atlassian.net/browse/DSND-2999)

[DSND-2999]: https://companieshouse.atlassian.net/browse/DSND-2999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ