### PR TITLE
DSND-3109: Add delta_at to delete delta test data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <!--companies house-->
     <structured-logging.version>3.0.14</structured-logging.version>
     <sdk-manager-java.version>3.0.9</sdk-manager-java.version>
-    <private-api-sdk-java.version>4.0.204</private-api-sdk-java.version>
+    <private-api-sdk-java.version>4.0.210</private-api-sdk-java.version>
     <data-sync-api-sdk-java.version>1.0.8</data-sync-api-sdk-java.version>
     <kafka-models.version>3.0.8</kafka-models.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,11 @@
       <artifactId>commons-compress</artifactId>
       <version>1.26.1</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <version>1.12.0</version>
+    </dependency>
     <!--end transitive dependencies-->
 
     <dependency>

--- a/src/test/resources/registers-delete-delta.json
+++ b/src/test/resources/registers-delete-delta.json
@@ -1,4 +1,5 @@
 {
   "company_number": "12345678",
-  "action": "DELETE"
+  "action": "DELETE",
+  "delta_at": "20230724093435661593"
 }


### PR DESCRIPTION
This PR updates the tests to ensure the consumer can handle a delta_at field on an incoming delete delta.

[DSND-3109](https://companieshouse.atlassian.net/browse/DSND-3109)

[DSND-3109]: https://companieshouse.atlassian.net/browse/DSND-3109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ