### PR TITLE
ASM-799 - update dependencies to resolve latest vulnerabilities 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,8 @@
     <maven-surefire-plugin.version>${maven-surefire.version}</maven-surefire-plugin.version>
     <maven-failsafe-plugin.version>${maven-surefire.version}</maven-failsafe-plugin.version>
     <commons-text.version>1.12.0</commons-text.version>
+    <commons-lang3.version>3.18.0</commons-lang3.version>
+    <tomcat-embed-core.version>11.0.11</tomcat-embed-core.version>
     <wiremock.version>3.9.1</wiremock.version>
 
     <skip.unit.tests>false</skip.unit.tests>
@@ -32,9 +34,10 @@
     <!--companies house-->
     <structured-logging.version>3.0.14</structured-logging.version>
     <sdk-manager-java.version>3.0.11</sdk-manager-java.version>
-    <private-api-sdk-java.version>4.0.210</private-api-sdk-java.version>
-    <data-sync-api-sdk-java.version>1.0.8</data-sync-api-sdk-java.version>
+    <private-api-sdk-java.version>4.0.360</private-api-sdk-java.version>
+    <data-sync-api-sdk-java.version>1.0.9</data-sync-api-sdk-java.version>
     <kafka-models.version>3.0.21</kafka-models.version>
+    <api-helper-java.version>3.0.2</api-helper-java.version>
 
     <!--explicit versions of transitive dependencies with vulnerabilities in previous versions-->
     <logback.version>1.4.14</logback.version>
@@ -72,12 +75,31 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>1.26.1</version>
+      <version>1.28.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
       <version>1.12.0</version>
+    </dependency>
+    <!-- CVE-2025-48924(5.3) -->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${commons-lang3.version}</version>
+    </dependency>
+    <dependency>
+      <!-- Added to resolve vulnerabilities in transitive dependencies for plexus-utils CVE-2022-4244;
+       sonar-scanner-api CVE-2023-3635(7.5), CVE-2018-20200(5.9) & CVE-2023-0833(5.5)-->
+      <groupId>uk.gov.companieshouse</groupId>
+      <artifactId>api-helper-java</artifactId>
+      <version>${api-helper-java.version}</version>
+    </dependency>
+    <dependency>
+      <!--Bump version resolves CVE-2025-48989(7.5) -->
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-core</artifactId>
+      <version>${tomcat-embed-core.version}</version>
     </dependency>
     <!--end transitive dependencies-->
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,9 +30,9 @@
     <skip.integration.tests>false</skip.integration.tests>
 
     <!--companies house-->
-    <structured-logging.version>3.0.14</structured-logging.version>
+    <structured-logging.version>3.0.40</structured-logging.version>
     <sdk-manager-java.version>3.0.9</sdk-manager-java.version>
-    <private-api-sdk-java.version>4.0.210</private-api-sdk-java.version>
+    <private-api-sdk-java.version>4.0.360</private-api-sdk-java.version>
     <data-sync-api-sdk-java.version>1.0.8</data-sync-api-sdk-java.version>
     <kafka-models.version>3.0.8</kafka-models.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,13 @@
       <artifactId>tomcat-embed-core</artifactId>
       <version>${tomcat-embed-core.version}</version>
     </dependency>
+    <dependency>
+      <!--Also for CVE-2025-48989(7.5) -->
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-websocket</artifactId>
+      <version>${tomcat-embed-core.version}</version>
+    </dependency>
+
     <!--end transitive dependencies-->
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,9 @@
   <properties>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
-    <spring.boot.version>3.3.4</spring.boot.version>
-    <jib-maven-plugin.version>3.4.2</jib-maven-plugin.version>
-    <test-containers.version>1.20.1</test-containers.version>
+    <spring.boot.version>3.5.4</spring.boot.version>
+    <jib-maven-plugin.version>3.4.6</jib-maven-plugin.version>
+    <test-containers.version>1.21.3</test-containers.version>
     <maven-surefire.version>3.5.0</maven-surefire.version>
     <maven-surefire-plugin.version>${maven-surefire.version}</maven-surefire-plugin.version>
     <maven-failsafe-plugin.version>${maven-surefire.version}</maven-failsafe-plugin.version>
@@ -30,11 +30,11 @@
     <skip.integration.tests>false</skip.integration.tests>
 
     <!--companies house-->
-    <structured-logging.version>3.0.40</structured-logging.version>
-    <sdk-manager-java.version>3.0.9</sdk-manager-java.version>
-    <private-api-sdk-java.version>4.0.360</private-api-sdk-java.version>
+    <structured-logging.version>3.0.14</structured-logging.version>
+    <sdk-manager-java.version>3.0.11</sdk-manager-java.version>
+    <private-api-sdk-java.version>4.0.210</private-api-sdk-java.version>
     <data-sync-api-sdk-java.version>1.0.8</data-sync-api-sdk-java.version>
-    <kafka-models.version>3.0.8</kafka-models.version>
+    <kafka-models.version>3.0.21</kafka-models.version>
 
     <!--explicit versions of transitive dependencies with vulnerabilities in previous versions-->
     <logback.version>1.4.14</logback.version>

--- a/src/test/java/uk/gov/companieshouse/registers/consumer/kafka/AbstractKafkaIT.java
+++ b/src/test/java/uk/gov/companieshouse/registers/consumer/kafka/AbstractKafkaIT.java
@@ -14,7 +14,7 @@ public abstract class AbstractKafkaIT {
 
     @Container
     protected static final KafkaContainer kafka = new KafkaContainer(DockerImageName.parse(
-            "confluentinc/cp-kafka:latest"));
+            "confluentinc/cp-kafka:latest")).withKraft();;
 
     @DynamicPropertySource
     static void props(DynamicPropertyRegistry registry) {


### PR DESCRIPTION
Resolves (https://companieshouse.atlassian.net/browse/ASM-799)[ASM-799]

Bump dependancy versions of 

- spring-boot
- jib-maven-plugin
- test-containers
- sdk-manager-java
- private-api-sdk-java
- data-sync-api-sdk
- kafka-models
- api-helper-java

Also added transitive dependency versions to resolve vuleneravitle where parent dependency was at latest version (private-api-sdk-java)

- commons-lang3
- tomcat-embed-core
- api-helper-java

Updated Kafka config to use Kraft to resolve issue with integration tests timing out where newest kafka test container image is no longer compatible with zookeeper

[ASM-799]: https://companieshouse.atlassian.net/browse/ASM-799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ