### PR TITLE
ASM-967 - Sonarqube migration - whitespace change to trigger build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # registers-delta-consumer
 Kafka consumer processing register election deltas from CHIPS into CHS
+ 


### PR DESCRIPTION
Resolves [ASM-967](https://companieshouse.atlassian.net/browse/ASM-967)

- Whitespace change in README to trigger build and complete final steps of migration of registers-delta-consumer to new Sonarqube version

[ASM-967]: https://companieshouse.atlassian.net/browse/ASM-967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ